### PR TITLE
Fixups for latest ci-agents patches:

### DIFF
--- a/cmd/overlay-runner/main.go
+++ b/cmd/overlay-runner/main.go
@@ -83,6 +83,10 @@ func loop(ctx *cli.Context) error {
 		errOut(err)
 	}
 
+	if err := c.Runner.Validate(); err != nil {
+		errOut(err)
+	}
+
 	if c.Hostname == "" {
 		c.Hostname = hostname
 	}

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/remyoudompheng/go-misc v0.0.0-20190302072532-28e3c191348b // indirect
 	github.com/securego/gosec v0.0.0-20190320213014-eaba99df3732 // indirect
-	github.com/tinyci/ci-agents v0.0.0-20190413110745-606db2e6d952
+	github.com/tinyci/ci-agents v0.0.0-20190419120227-c065842ca076
 	github.com/urfave/cli v1.20.0
 	golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c // indirect
 	golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,7 @@ github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
+github.com/openshift/osin v1.0.1/go.mod h1:/gGuqQHvGNST0GB+Pomi3398FTdcM+9UaXafpqHvfDM=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
@@ -165,6 +166,8 @@ github.com/tinyci/ci-agents v0.0.0-20190412094846-f42375eed251 h1:EvooRhzmErOjfO
 github.com/tinyci/ci-agents v0.0.0-20190412094846-f42375eed251/go.mod h1:v2OV5yEJpSploh4XsbsMSXEWbaVk6GM5wSoEgMBPMmE=
 github.com/tinyci/ci-agents v0.0.0-20190413110745-606db2e6d952 h1:2YA8nhz9SJ/Ck2ih4YZQkcIE1Mq0P+HjBdw56mjPafg=
 github.com/tinyci/ci-agents v0.0.0-20190413110745-606db2e6d952/go.mod h1:v2OV5yEJpSploh4XsbsMSXEWbaVk6GM5wSoEgMBPMmE=
+github.com/tinyci/ci-agents v0.0.0-20190419120227-c065842ca076 h1:lfI94wRc3FDHvz1HURKlejRiIM48Z+x+NsZjukKubkc=
+github.com/tinyci/ci-agents v0.0.0-20190419120227-c065842ca076/go.mod h1:YqYoHZrJSZnmw5qLXv2x1xJYYWX/1xjtUgejIOmJ8To=
 github.com/ugorji/go/codec v0.0.0-20181209151446-772ced7fd4c2 h1:EICbibRW4JNKMcY+LsWmuwob+CRS1BmdRdjphAm9mH4=
 github.com/ugorji/go/codec v0.0.0-20181209151446-772ced7fd4c2/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
@@ -187,6 +190,7 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190320064053-1272bf9dcd53/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190327091125-710a502c58a2 h1:17UhVDrPb40BH5k6cyeb2V/7QlBNdo/a0+r0dtK+Utw=
 golang.org/x/net v0.0.0-20190327091125-710a502c58a2/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190328230028-74de082e2cca h1:hyA6yiAgbUwuWqtscNvWAI7U1CtlaD1KilQ6iudt1aI=
 golang.org/x/net v0.0.0-20190328230028-74de082e2cca/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190319182350-c85d3e98c914 h1:jIOcLT9BZzyJ9ce+IwwZ+aF9yeCqzrR+NrD68a/SHKw=

--- a/runner/git.go
+++ b/runner/git.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"io"
 
+	"github.com/tinyci/ci-agents/clients/log"
+	"github.com/tinyci/ci-agents/types"
 	"github.com/tinyci/ci-runners/git"
-	"golang.org/x/oauth2"
 )
 
 func jsonIO(from, to interface{}) error {
@@ -18,35 +19,50 @@ func jsonIO(from, to interface{}) error {
 }
 
 // PullRepo retrieves the repository and puts it in the right spot.
-func (r *Run) PullRepo(log io.Writer) (*git.RepoManager, error) {
-	queueTok := r.QueueItem.Run.Task.Parent.Owners[0].Token
-	tok := &oauth2.Token{}
+func (r *Run) PullRepo(w io.Writer) (*git.RepoManager, error) {
+	queueTok := r.QueueItem.Run.Task.Parent.Owner.Token
+	tok := &types.OAuthToken{}
 
 	if err := jsonIO(queueTok, tok); err != nil {
 		return nil, err
 	}
 
 	rm := &git.RepoManager{
-		Log:          log,
-		AccessToken:  tok.AccessToken,
+		Log:          w,
+		AccessToken:  tok.Token,
 		BaseRepoPath: r.Config.Runner.BaseRepoPath,
 	}
 
+	wf := r.Config.Clients.Log.WithFields(log.FieldMap{
+		"owner":          r.QueueItem.Run.Task.Parent.Owner.Username,
+		"base_repo_path": r.Config.Runner.BaseRepoPath,
+		"repo_name":      r.QueueItem.Run.Task.Parent.Name,
+	})
+
 	if err := rm.Init(r.Config, r.QueueItem.Run.Task.Parent.Name, r.QueueItem.Run.Task.Ref.Repository.Name); err != nil {
+		wf.Errorf("Error initializing repo: %v", err)
 		return nil, err
 	}
 
 	if err := rm.CloneOrFetch(); err != nil {
+		wf.Errorf("Error cloning repo: %v", err)
 		return nil, err
 	}
 
 	if err := rm.AddOrFetchFork(); err != nil {
+		wf.Errorf("Error cloning fork: %v", err)
 		return nil, err
 	}
 
 	if err := rm.Checkout(r.QueueItem.Run.Task.Ref.SHA); err != nil {
+		wf.Errorf("Error checking out %v: %v", r.QueueItem.Run.Task.Ref.SHA, err)
 		return nil, err
 	}
 
-	return rm, rm.Merge("origin/master")
+	if err := rm.Merge("origin/master"); err != nil {
+		wf.Errorf("Error merging master for %v: %v", r.QueueItem.Run.Task.Ref.SHA, err)
+		return nil, err
+	}
+
+	return rm, nil
 }


### PR DESCRIPTION
* Bring in latest ci-agents repo
* Remove all references to oauth2 tokens (use our types lib)
* Lots of logging
* Finally, validate the configuration file which will populate it with
  the default values

Signed-off-by: Erik Hollensbe <github@hollensbe.org>