### PR TITLE
Duplicate log messages in console

### DIFF
--- a/runners/overlay-runner/docker.go
+++ b/runners/overlay-runner/docker.go
@@ -18,6 +18,10 @@ import (
 	"github.com/tinyci/ci-runners/fw/overlay"
 )
 
+func init() {
+	color.NoColor = false
+}
+
 func processLine(m map[string]interface{}, idMap map[string][]float64) bool {
 	var completed bool
 


### PR DESCRIPTION
This makes runner debugging simpler and logsvc access is not required